### PR TITLE
fixed TODO to allow user to pause the audio or replay it if it ended and also prevents audios from overlapping

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -79,18 +79,35 @@ selectedArticle.on("click", function (event) {
   fetchTTS(selectedDescText);
 });
 
+var audio = null;
 /* Fetches VoiceRSS Text-to-Speech API with the selected article's description text as a query parameter.
 The function generates an audio format in the browser window which plays a voice reading the selected article's description*/
 function fetchTTS(text) {
-  const API_KEY = "e5bd0e9876784ba4b37cb873babe6e39";
-  const voice = "en-gb";
-  const format = "MP3";
-  const speed = 0;
-  const requestUrl = `http://api.voicerss.org/?key=${API_KEY}&src=${text}&hl=${voice}&c=${format}&f=44khz_16bit_stereo&r=${speed}`;
+    const API_KEY = "e5bd0e9876784ba4b37cb873babe6e39";
+    const language = "en-us";
+    const voice = "Mike";
+    const codec = "MP3";
+    const format = "alaw_22khz_mono";
+    const speed = 0;
+    const requestUrl = `http://api.voicerss.org/?key=${API_KEY}&src=${text}&hl=${language}&v=${voice}&c=${codec}&f=${format}&r=${speed}`;
 
-  const audio = new Audio(requestUrl);
-  audio.play();
+    //Checks if there's a current existing audio so audio's don't overlap
+    if (audio === null) {
+        audio = new Audio(requestUrl);
+        audio.play();
+    } else {
+        //If the audio is currently playing, then pause it and set audio to null (so the next time the user clicks the element, it will restart the audio)
+        if (!audio.paused) {
+            audio.pause();
+            audio = null;
+        }
+        //If the audio finished and the user clicks the element again, it replays the audio
+        else if (audio.ended) {
+            audio.play();
+        }
+    }
 }
+
 
 /* Runs the userFormSubmit function when the form on the screen is submitted */
 userTopicForm.submit(userFormSubmit);


### PR DESCRIPTION
The issue before was that every time the user would click on the container, a new audio object would be generated, leading to multiple audios overlapping each other. To fix this, I check if an audio object is currently existing, and only create a new audio object if there is no other audio currently existing.

Also added a feature to check the current status of the audio when the user clicks on the container. If there is a current audio existing and it is playing, then when the user clicks the container it will pause the audio and set it to null, so the next time the user clicks the container it will begin the audio from the beginning. If the audio ends and the user clicks the container, it will replay the audio from the beginning.

The reason we restart the audio is that the description is a small section. If the audio was to read the entire article, we would allow the click event on the container to pause and resume the audio rather than restarting it.