### PR TITLE
Fixed audio issue to pause audio when user swipes through carousel

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -66,6 +66,10 @@ function getNewsArticles(data) {
 var selectedArticle = $(".carousel-item");
 selectedArticle.on("click", function (event) {
   if ($(event.target).is("a")) {
+    if (audio) {
+      audio.pause();
+    }
+    audio = null;
     return;
   }
   //Gets the footer element of the article that is selected
@@ -121,7 +125,7 @@ makes an api call to return the top 7 articles for a trend (first 5 will appear 
 displayed below the carousel)*/
 function displayTrends(trend) {
   const trendTopic = trend.attr("id");
-  const apikey = "0a81fd50979ee58ec90f9d378ec0e3ef";
+  const apikey = "6c567cc9914a3b820af13132977057d8";
   const trendUrl = `https://gnews.io/api/v4/top-headlines?topic=${trendTopic}&token=${apikey}&lang=en&country=us&max=7`;
 
   fetch(trendUrl)
@@ -151,9 +155,9 @@ function displayTrends(trend) {
 }
 
 $(document).ready(function () {
-  var trendBreaking = $("#breaking-news");
-  var trendWorld = $("#world");
-  var trendEntertainment = $("#entertainment");
+  const trendBreaking = $("#breaking-news");
+  const trendWorld = $("#world");
+  const trendEntertainment = $("#entertainment");
 
   displayTrends(trendBreaking);
   displayTrends(trendWorld);


### PR DESCRIPTION
When the user would click an article to play the audio and then swipe through the carousel, the audio would still be playing. This addition stops the audio when the user swipes through the carousel.